### PR TITLE
Fix misnamed listener and cache lookup

### DIFF
--- a/services/agent-manager/src/services/agentCommunicator.ts
+++ b/services/agent-manager/src/services/agentCommunicator.ts
@@ -32,10 +32,10 @@ export class AgentCommunicator extends EventEmitter {
     super();
     this.io = io;
     this.agentRegistry = agentRegistry;
-    this.setupOrchestorListeners();
+    this.setupOrchestratorListeners();
   }
 
-  private setupOrchestorListeners(): void {
+  private setupOrchestratorListeners(): void {
     // Listen for task assignments from orchestrator
     this.agentRegistry.on('task:assigned', (task: Task, agent: Agent) => {
       this.sendTaskToAgent(agent.id, task);
@@ -60,7 +60,7 @@ export class AgentCommunicator extends EventEmitter {
     const agentVerificationPromise = new Promise<void>(async (resolve, reject) => {
       try {
         // First, try to get the agent from registry
-        const existingAgent = await this.agentRegistry.getAgent(agentId);
+        const existingAgent = await this.agentRegistry.getAgentAsync(agentId);
         
         if (existingAgent) {
           // Agent exists, update status


### PR DESCRIPTION
## Summary
- correct a typo in AgentCommunicator's method name
- use async `getAgentAsync` when verifying connections

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_e_6846efce69e883229935d02444e8b16a